### PR TITLE
Adding a VS Code devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,20 @@
+# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.241.1/containers/ubuntu/.devcontainer/base.Dockerfile
+
+# [Choice] Ubuntu version (use ubuntu-22.04 or ubuntu-18.04 on local arm64/Apple Silicon): ubuntu-22.04, ubuntu-20.04, ubuntu-18.04
+ARG VARIANT="jammy"
+FROM mcr.microsoft.com/vscode/devcontainers/base:0-${VARIANT}
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install basic apt packages
+RUN apt-get update && apt-get install gettext-base && rm -rf /var/lib/apt/lists/*
+
+# Install apt packages
+COPY apt.txt /tmp/
+RUN echo $(cat /tmp/apt.txt | cut -d# -f1 | envsubst)
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+     && apt-get -y install --no-install-recommends $(cat /tmp/apt.txt | cut -d# -f1 | envsubst) \
+     && rm -rf /var/lib/apt/lists/*
+
+COPY requirements.txt /tmp
+RUN pip3 install -r /tmp/requirements.txt

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,31 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.241.1/containers/ubuntu
+{
+	"name": "Ubuntu",
+	"build": {
+		"dockerfile": "Dockerfile",
+		// Update 'VARIANT' to pick an Ubuntu version: jammy / ubuntu-22.04, focal / ubuntu-20.04, bionic /ubuntu-18.04
+		// Use ubuntu-22.04 or ubuntu-18.04 on local arm64/Apple Silicon.
+		"args": { "VARIANT": "ubuntu-22.04" },
+		"context": "..",
+	},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "uname -a",
+
+	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+	"remoteUser": "vscode",
+	"features": {
+		"python": "os-provided"
+	},
+    "containerEnv": {
+        "DISPLAY": "unix:0"
+    },
+    "mounts": [
+        "source=/tmp/.X11-unix,target=/tmp/.X11-unix,type=bind,consistency=cached"
+      ],
+    "runArgs": ["--privileged"]
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,7 +7,7 @@
 		// Update 'VARIANT' to pick an Ubuntu version: jammy / ubuntu-22.04, focal / ubuntu-20.04, bionic /ubuntu-18.04
 		// Use ubuntu-22.04 or ubuntu-18.04 on local arm64/Apple Silicon.
 		"args": { "VARIANT": "ubuntu-22.04" },
-		"context": "..",
+		"context": ".."
 	},
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
@@ -19,7 +19,7 @@
 	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
 	"remoteUser": "vscode",
 	"features": {
-		"python": "os-provided"
+		"python": "3.8.10"
 	},
     "containerEnv": {
         "DISPLAY": "unix:0"

--- a/apt.txt
+++ b/apt.txt
@@ -1,0 +1,1 @@
+python3-pip


### PR DESCRIPTION
# Description

This PR adds a `.devcontainer` to the repo. You can then use VS Code and open the repo in a container with Python 3.8.10 and all the required apt packages (listed in apt.txt).

Fixes # (issue)

It creates a universal development environment for all the developers that can be updated with the progress of the project. Hopefully, it will work on Linux, Windows and macOS (the requirements are Docker and VS Code).

## Type of change

Please delete options that are not relevant.

- [x ] New feature (non-breaking change which adds functionality)
- [x ] This change requires a documentation update

# How Has This Been Tested?

I have tested it on WSL2 on a Windows machine.

**Test Configuration**:
* Firmware version: Windows
* Hardware: AMD64

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
